### PR TITLE
fix: use dtype instead of deprecated torch_dtype

### DIFF
--- a/transformers_impl/inference.py
+++ b/transformers_impl/inference.py
@@ -61,7 +61,7 @@ def main(args):
     # device_map="auto" will handle placing the model on available GPUs
     model = LLaVAOneVision1_5_ForConditionalGeneration.from_pretrained(
         args.model_path, 
-        torch_dtype="auto", 
+        dtype="auto", 
         device_map="auto",
         trust_remote_code=False # Recommended for custom models
     )


### PR DESCRIPTION
## Summary

The `torch_dtype` keyword argument of `from_pretrained` was deprecated in transformers 4.56 (PR #39782) and replaced by `dtype`. This PR updates the `LLaVAOneVision1_5_ForConditionalGeneration.from_pretrained` call in `transformers_impl/inference.py` (line 64) to use `dtype="auto"`. The repository pins `transformers==5.7.0`, so the new keyword is always supported. All other arguments (`device_map`, `trust_remote_code`) are unchanged.

## Changes

- `transformers_impl/inference.py`: `torch_dtype="auto"` → `dtype="auto"` in the model loading call.

## Test

- The modified file compiles (`python -m py_compile`).
- On the pinned transformers 5.7.0, the call accepts `dtype` with identical behavior; on 4.56+ the deprecation warning is gone.

Fixes #197